### PR TITLE
TSFF-1423: Legg til mellomrom under overskrifter for fraværsperioder og delvis fraværsdager

### DIFF
--- a/content/templates/omsorgspenger_refusjon/template.hbs
+++ b/content/templates/omsorgspenger_refusjon/template.hbs
@@ -38,7 +38,7 @@
 * <span>{{fom}} - {{tom}}</span>
 {{/each}}
 {{else}}
-Ingen dager med fravær bare deler av dagen
+<br>Ingen dager med fravær bare deler av dagen
 {{/if}}
 **Dager med fravær bare deler av dagen**
 {{~#if delvisFraværsPerioder.length}}
@@ -46,7 +46,7 @@ Ingen dager med fravær bare deler av dagen
 * <span>{{dato}}, {{timer}} timer</span>
 {{/each}}
 {{else}}
-Ingen dager med fravær bare deler av dagen
+<br>Ingen dager med fravær bare deler av dagen
 {{/if}}
 {{~#if trukketFraværsPerioder.length}}
 **Dager som skal trekkes**


### PR DESCRIPTION
### **Behov / Bakgrunn**
I forbindelse med endringene i https://github.com/navikt/k9-dokgen/pull/287, glemte vi å legge til mellomrom under overskriftene.

### **Løsning**
Legg til mellomrom