### PR TITLE
TSFF-1739: Legg til ny pdf for inntektsmelding omsorgspenger

### DIFF
--- a/content/templates/omsorgspenger_inntektsmelding/schema.json
+++ b/content/templates/omsorgspenger_inntektsmelding/schema.json
@@ -1,0 +1,108 @@
+{
+  "$id": "k9-inntektsmelding",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Dokumentdata for generering av pdf av inntektsmelding",
+  "type": "object",
+  "required": [
+    "avsenderSystem",
+    "navnSøker",
+    "personnummer",
+    "arbeidsgiverIdent",
+    "arbeidsgiverNavn",
+    "månedInntekt",
+    "opprettetTidspunkt",
+    "kontaktperson",
+    "fraværsperioder",
+    "harUtbetaltLønn"
+  ],
+  "$defs": {
+    "endringsarsak" : {
+      "type": "object",
+      "required": [
+        "arsak"
+      ],
+      "properties": {
+        "arsak": {
+          "type": "string"
+        },
+        "fom": {
+          "type": "string"
+        },
+        "tom": {
+          "type": "string"
+        },
+        "bleKjentFra": {
+          "type": "string"
+        }
+      }
+    },
+    "fraværsPeriode": {
+      "type": "object",
+      "properties": {
+        "fom": {
+          "type": "string"
+        },
+        "tom": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "fom",
+        "tom"
+      ]
+    }
+  },
+  "properties": {
+    "avsenderSystem": {
+      "type": "string"
+    },
+    "navnSøker": {
+      "type": "string"
+    },
+    "personnummer": {
+      "type": "string"
+    },
+    "arbeidsgiverIdent": {
+      "type": "string"
+    },
+    "arbeidsgiverNavn": {
+      "type": "string"
+    },
+    "kontaktperson": {
+      "type": "object",
+      "required": [
+        "navn",
+        "telefonnummer"
+      ],
+      "properties": {
+        "navn": {
+          "type": "string"
+        },
+        "telefonnummer": {
+          "type": "string"
+        }
+      }
+    },
+    "månedInntekt": {
+      "type": "number"
+    },
+    "opprettetTidspunkt": {
+      "type": "string"
+    },
+    "endringsarsaker": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/endringsarsak"
+      }
+    },
+    "fraværsPerioder": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/fraværsPeriode"
+      }
+    },
+    "årForRefusjon": {
+      "type": "number"
+    }
+  }
+}

--- a/content/templates/omsorgspenger_inntektsmelding/template.hbs
+++ b/content/templates/omsorgspenger_inntektsmelding/template.hbs
@@ -1,0 +1,42 @@
+<div class="align"> <p> Innsendt: {{opprettetTidspunkt}}</p></div>
+<br>
+<br>
+<br>
+
+# Inntektsmelding omsorgspenger
+
+## Arbeidsgiver og den ansatte
+
+**Arbeidsgiver**
+<br>{{arbeidsgiverNavn}}, org.nr. {{arbeidsgiverIdent}}
+
+**Kontaktperson fra bedriften**
+<br>{{kontaktperson.navn}}, tlf. {{kontaktperson.telefonnummer}}
+
+**Den ansatte**
+<br>{{navnSøker}}, f.nr. {{personnummer}}
+
+<hr>
+
+## Om fraværet
+
+**Dager med oppgitt fravært**
+{{~#each fraværsperioder}}
+* <span>{{fom}} - {{tom}}</span>
+{{/each}}
+
+**Har dere utbetalt lønn for dette fraværet?**
+<br>{{harUtbetaltLønn}}
+
+<hr>
+
+## Månedslønn
+**Beregnet månedslønn**
+<br>{{thousand-seperator-double månedInntekt}} kr
+{{#if endringsarsaker.length}}
+**Årsaker til endring av inntekt**
+{{~#each endringsarsaker}}
+* <span>{{arsak}}{{#if (and fom tom)}}: {{fom}} - {{tom}} {{else if fom}}: fra og med {{fom}} {{#if bleKjentFra}} , ble kjent fra og med {{bleKjentFra}}{{/if}}{{else}}{{/if}}</span>
+{{/each}}
+{{/if}}
+

--- a/content/templates/omsorgspenger_inntektsmelding/testdata/test.json
+++ b/content/templates/omsorgspenger_inntektsmelding/testdata/test.json
@@ -1,0 +1,21 @@
+{
+  "avsenderSystem": "nav.no/arbeidsgiverportalen",
+  "navnSøker": "Gro Gror Testesen",
+  "fornavnSøker": "Gro",
+  "personnummer": "*********5298",
+  "arbeidsgiverIdent": "*****4556",
+  "arbeidsgiverNavn": "Arbeidsgiver 1",
+  "kontaktperson": {
+    "navn": "Navn kontaktperson",
+    "telefonnummer": "22 22 22 22"
+  },
+  "månedInntekt": 56000.50,
+  "opprettetTidspunkt": "31. mai 2024 kl.12.20",
+  "fraværsPerioder": [
+    {
+      "fom": "2024-05-31",
+      "tom": "2024-06-30"
+    }
+  ],
+  "harUtbetaltLønn": "Ja"
+}


### PR DESCRIPTION
### **Behov / Bakgrunn**
Inntektsmeldingen for omsorgspenger ser litt annerledes ut enn den for pleiepenger. Den er også forskjellig fra refusjonskrav for omsorgspenger. Vi ønsker derfor å mappe ut egne pdf info og gå mot en nytt endepunkt i `k9-dokgen`.

Jira: https://jira.adeo.no/browse/TSFF-1739

### **Løsning**
Legger til ny pdf-mal som speiler oppsummeringen i frontend. 

Relevant PR: https://github.com/navikt/k9-inntektsmelding/pull/483

### **Skjermbilder** (hvis relevant)
![im omp oppsummering](https://github.com/user-attachments/assets/e52a3ed7-ccfc-4c86-849e-7b868de77033)
