### PR TITLE
Fiks: fjern metadata

### DIFF
--- a/content/formats/pdf/header.html
+++ b/content/formats/pdf/header.html
@@ -1,22 +1,12 @@
 <div id="header">
     <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-    <svg xmlns:dc="http://purl.org/dc/elements/1.1/"
-         xmlns:cc="http://creativecommons.org/ns#"
-         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-         xmlns:svg="http://www.w3.org/2000/svg"
-         xmlns="http://www.w3.org/2000/svg"
+    <svg xmlns="http://www.w3.org/2000/svg"
          viewBox="0 0 704 443.10666"
          height="444"
          width="704"
          xml:space="preserve"
          id="nav_logo"
          version="1.1">
-        <metadata id="metadata8"><rdf:RDF><cc:Work rdf:about="">
-            <dc:format>image/svg+xml</dc:format>
-            <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        </cc:Work>
-        </rdf:RDF>
-        </metadata>
         <defs id="defs6" > </defs>
         <g transform="matrix(1.3333333,0,0,-1.3333333,0,443.10667)" id="g10">
             <g transform="scale(0.1)" id="g12">


### PR DESCRIPTION
### **Behov / Bakgrunn**
I nyeste versjon av dokgen er det en breaking change. Jsoup støtter ikke lenger metadata med RDF.

### **Løsning**
Fjerner metadata siden det ikke påvirker det visuelle. 
