### PR TITLE
Dependabot: setter cooldown til 7 dager

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,23 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      exclude:
+        - "no.nav.*"
+
   - package-ecosystem: docker
     directory: "/"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
- 
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
### **Behov / Bakgrunn**
For å beskytte oss mot pakkeoppdateringer med ondsinnet programvare ønsker vi å vente med å bumpe til den nyeste versjonen.

### **Løsning**
Innfører 7 dagers delay for oppdateringer. Unntak for pakker fra "no.nav.*" siden de burde ha ventet 7 dager allerede.
