### PR TITLE
Dependabot: Trenger ikke cooldown for images fra dokgen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,6 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
-    cooldown:
-      default-days: 7
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
### **Behov / Bakgrunn**
K9-dokgen henter image fra nav sitt dokgen. Det brude være verifisert så vi trenger ikke ytterligere 7 dager cooldown.

### **Løsning**
Fjerner cooldown for images 